### PR TITLE
fix check for recurring event until date/time

### DIFF
--- a/src/When.php
+++ b/src/When.php
@@ -615,7 +615,7 @@ class When extends \DateTime
             }
         }
 
-        while ($dateLooper < $this->until && count($this->occurrences) < $this->count)
+        while ($dateLooper <= $this->until && count($this->occurrences) < $this->count)
         {
             if ($this->freq === "yearly")
             {


### PR DESCRIPTION
When getting occurence for a recurring event, the last event was ignored 
